### PR TITLE
Add check_prerequisite and cache helpers

### DIFF
--- a/miflora/backends/__init__.py
+++ b/miflora/backends/__init__.py
@@ -12,14 +12,22 @@ class AbstractBackend(object):
     def __del__(self):
         self.disconnect()
 
+    def check_prerequisites(self):
+        """Check if the backend is ready to be used.
+
+        Returns True if all requirements are met, False otherwise
+
+        only required by some backends"""
+        return True
+
     def connect(self, mac):
-        """connect to a device with the given @mac.
+        """Connect to a device with the given @mac.
 
         only required by some backends"""
         raise NotImplemented
 
     def disconnect(self):
-        """disconnect from a device.
+        """Disconnect from a device.
 
         only required by some backends"""
         raise NotImplemented

--- a/miflora/backends/gatttool.py
+++ b/miflora/backends/gatttool.py
@@ -25,6 +25,10 @@ class GatttoolBackend(AbstractBackend):
         self.retries = retries
         self.timeout = timeout
 
+    def check_prerequisites():
+        # gatttool is an external command and it's existence and operation need to be checked
+        return not call("command -v gatttool", shell=True, stdout=PIPE, stderr=PIPE)
+
     def connect(self,mac):
         # connection handling is not required when using gatttool, but we still need the mac
         self.mac = mac

--- a/miflora/miflora_poller.py
+++ b/miflora/miflora_poller.py
@@ -36,6 +36,9 @@ class MiFloraPoller(object):
         self.ble_timeout = 10
         self.lock = Lock()
         self._firmware_version = None
+        if not self.backend.check_prerequisites():
+            raise FileNotFoundError("The prerquisites for your backend are not met. " +
+                "Please resolve the issue and try again.")
 
     def name(self):
         """
@@ -48,6 +51,10 @@ class MiFloraPoller(object):
         if not name:
             raise IOError("Could not read data from Mi Flora sensor %s" % (self._mac))
         return ''.join(chr(n) for n in name)
+
+    def clear_cache(self):
+        self._cache = None
+        self._last_read = None
 
     def fill_cache(self):
         firmware_version = self.firmware_version()
@@ -73,6 +80,9 @@ class MiFloraPoller(object):
             self._last_read = datetime.now() - self._cache_timeout + \
                 timedelta(seconds=300)
         self.backend.disconnect(self._mac)
+
+    def cache_available(self):
+        return self._cache is not None
 
     def battery_level(self):
         """


### PR DESCRIPTION
Transferred from https://github.com/open-homeautomation/miflora/pull/36

This PR adds a check for prerequisites to the backend definition. In case of gatttool we need to check if it is available prior to using the functions `write_ble/read_ble`.
Furthermore I've added two helper functions: It might be important to know that data is available in the cache and in certain situations one might want to purge the cache manually.

@ChristianKuehnel this might be a bit surprising. I've taken your latest PR as the base for this fork. The PR is a small addition that might turn out helpful. Wdyt?